### PR TITLE
fix local variable name in constructor

### DIFF
--- a/src/Ssh/Session.php
+++ b/src/Ssh/Session.php
@@ -25,7 +25,7 @@ class Session extends AbstractResourceHolder
     {
         $this->configuration  = $configuration;
         $this->authentication = $authentication;
-        $this->subsystem      = array();
+        $this->subsystems      = array();
     }
 
     /**


### PR DESCRIPTION
the local variable inside the constructor should be `subsystems` instead of `subsystem`, when the names don't match it's a creation of dynamic property in the constructor which doesn't work with php8.2 anymore